### PR TITLE
fix: handle array-based tag.text reasons

### DIFF
--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -289,7 +289,11 @@ function isCallExpression(
 function getJsDocDeprecation(tags: ts.JSDocTagInfo[]) {
   for (const tag of tags) {
     if (tag.name === 'deprecated') {
-      return { reason: tag.text || '' };
+      let reason = tag.text;
+      if (Array.isArray(reason)) {
+        reason = reason.map(val => val.text).join('');
+      }
+      return { reason: reason || '' };
     }
   }
   return undefined;


### PR DESCRIPTION
A change in TypeScript made jsdoc tag.text (sometimes?) an Array, rather
than the plain string it always used to be.